### PR TITLE
Feature: Add editor dark mode

### DIFF
--- a/Guides/Developing.md
+++ b/Guides/Developing.md
@@ -4,7 +4,7 @@
 
 To run Sequel Ace locally from XCode, please:
 - download `.zip` archive of this repo/clone locally
-- open `sequel-ace.xcworkspace` 
+- open `sequel-ace.xcodeproj` 
 - for the `sequel-ace` and `SPMySQLFramework`  (located in `Source/Frameworks/SPMySQLFramework`) projects, under `Signing & Capibilities`
     - change the Bundle Identifier to be unique to you (e.g. add `.YOUR_USER_NAME`)
     - select a Team that you can create signing certificates for

--- a/Resources/Plists/PreferenceDefaults.plist
+++ b/Resources/Plists/PreferenceDefaults.plist
@@ -65,30 +65,52 @@
 	<false/>
 	<key>CustomQueryEditorBackgroundColor</key>
 	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmAQEBAYY=</data>
+	<key>CustomQueryEditorDarkModeBackgroundColor</key>
+	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmgzqlCj6DBeYZPoOAbio+AYY=</data>
 	<key>CustomQueryEditorBacktickColor</key>
 	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmAACDqagoPwGG</data>
+	<key>CustomQueryEditorDarkModeBacktickColor</key>
+	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmg5DkfT+DprEVP4NJUQs9AYY=</data>
 	<key>CustomQueryEditorCaretColor</key>
 	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmAAAAAYY=</data>
+	<key>CustomQueryEditorDarkModeCaretColor</key>
+	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmg5J6Xz6Dj42OPoNxt6Y+AYY=</data>
 	<key>CustomQueryEditorCommentColor</key>
 	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmAIPp6Og+AAGG</data>
+	<key>CustomQueryEditorDarkModeCommentColor</key>
+	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmg4h01T6D7hxFP4ObOOQ+AYY=</data>
 	<key>CustomQueryEditorFont</key>
 	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAZOU0ZvbnQehIQITlNPYmplY3QAhYQBaSSEBVszNmNdBgAAABwAAAD//k0AZQBuAGwAbwAtAFIAZQBnAHUAbABhAHIAhAFmDoQBYwCYAZgAmACG</data>
 	<key>CustomQueryEditorHighlightQueryColor</key>
 	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARmZmZmgzMzcz+DMzNzP4MzM3M/AYY=</data>
+	<key>CustomQueryEditorDarkModeHighlightQueryColor</key>
+	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmgwyvJz6DsuI6PoOKuU8+AYY=</data>
 	<key>CustomQueryEditorNumericColor</key>
 	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmg4GAAD+Dh4aGPgABhg==</data>
+	<key>CustomQueryEditorDarkModeNumericColor</key>
+	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmg3o2Xj+DKN74PoOxmuU8AYY=</data>
 	<key>CustomQueryEditorQuoteColor</key>
 	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmg8bFRT+DnXPOPYNba609AYY=</data>
+	<key>CustomQueryEditorDarkModeQuoteColor</key>
+	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmg5DkfT+DprEVP4NJUQs9AYY=</data>
 	<key>CustomQueryEditorSelectionColor</key>
 	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARmZmZmg7a1NT+D1tVVPwEBhg==</data>
+	<key>CustomQueryEditorDarkModeSelectionColor</key>
+	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmg5J6Xz6Dj42OPoNxt6Y+AYY=</data>
 	<key>CustomQueryEditorSQLKeywordColor</key>
 	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmg83MTD6DnXPOPQEBhg==</data>
+	<key>CustomQueryEditorDarkModeSQLKeywordColor</key>
+	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmg1tGLz2D35LGPoOalX8/AYY=</data>
 	<key>CustomQueryEditorTabStopWidth</key>
 	<integer>4</integer>
 	<key>CustomQueryEditorTextColor</key>
 	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmAAAAAYY=</data>
+	<key>CustomQueryEditorDarkModeTextColor</key>
+	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmg8Tzbz+DxPNvP4PE828/AYY=</data>
 	<key>CustomQueryEditorVariableColor</key>
 	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmg3zv/T6DfO/9PoN87/0+AYY=</data>
+	<key>CustomQueryEditorDarkModeVariableColor</key>
+	<data>BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMBhARmZmZmgwe8bj+Di3w0P4MfjQw9AYY=</data>
 	<key>CustomQueryFunctionCompletionInsertsArguments</key>
 	<true/>
 	<key>CustomQueryHighlightCurrentQuery</key>

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -698,7 +698,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     }
 
     // Start a task
-    [self startTaskWithDescription:[NSString stringWithFormat:NSLocalizedString(@"Loading database '%@'...", @"Loading database task string"), [[chooseDatabaseButton onMainThread] titleOfSelectedItem]]];
+    [self startTaskWithDescription:[NSString stringWithFormat:NSLocalizedString(@"Loading database '%@'...", @"Loading database task string"), database]];
 
     NSDictionary *selectionDetails = [NSDictionary dictionaryWithObjectsAndKeys:database, @"database", item, @"item", nil];
 

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -5391,7 +5391,7 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
             [[chooseDatabaseButton onMainThread] selectItemWithTitle:targetDatabaseName];
 
             selectedDatabase = [[NSString alloc] initWithString:targetDatabaseName];
-            selectedTableName = targetItemName ? [[NSString alloc] initWithString:targetItemName] : nil;
+            selectedTableName = nil;
 
             [databaseDataInstance resetAllData];
 

--- a/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
+++ b/Source/Controllers/MainViewControllers/SPDatabaseDocument.m
@@ -1065,7 +1065,13 @@ static _Atomic int SPDatabaseDocumentInstanceCounter = 0;
     [gotoDatabaseController setDatabaseList:dbList];
 
     if ([gotoDatabaseController runModal]) {
-        [self selectDatabase:[gotoDatabaseController selectedDatabase] item:nil];
+        NSString *database =[gotoDatabaseController selectedDatabase];
+        if ([database rangeOfString:@"."].location != NSNotFound){
+            NSArray *components = [database componentsSeparatedByString:@"."];
+            [self selectDatabase:[components firstObject] item:[components lastObject]];
+        }else{
+            [self selectDatabase:database item:nil];
+        }
     }
 }
 

--- a/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
+++ b/Source/Controllers/MainViewControllers/TableStructure/SPTableStructure.m
@@ -945,8 +945,23 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
                 unichar firstChar = [trimmedWhiteSpace characterAtIndex:0];
                 unichar lastChar = [trimmedWhiteSpace characterAtIndex:[trimmedWhiteSpace length] - 1];
                 // Check if defaultValue is an expression
-                if ((firstChar == '(') && (lastChar = ')')) {
+                if (lastChar == ')') {
+                    // To check if brackets appear in pairs, then we assume the string is possibly an expression
+                    // if it's expression by this check so query will be executed and an error will be shown
+                    // TODO: Best possible solution would be checking the input value against the list of known functions/keywords
+                    NSUInteger checkBracketPairs = 0;
+                    for (NSUInteger i = 0; i < [trimmedWhiteSpace length]; i++) {
+                        if ([trimmedWhiteSpace characterAtIndex:i] == '(') {
+                          checkBracketPairs++;
+                        } else if ([trimmedWhiteSpace characterAtIndex:i] == ')') {
+                          checkBracketPairs--;
+                        }
+                    }
+                  
+                  // it means brackets are in pairs
+                  if (checkBracketPairs == 0) {
                     defaultValueIsExpression = YES;
+                  }
                 }
                 // Check if defaultValue is a string in quotes (single or double)
                 else if ( ((firstChar == '"') && (lastChar = '"')) || ((firstChar == '\'') && (lastChar = '\'')) ) {
@@ -982,8 +997,8 @@ static void _BuildMenuWithPills(NSMenu *menu,struct _cmpMap *map,size_t mapEntri
 			else if ([theRowType isEqualToString:@"BIT"]) {
 				[queryString appendFormat:@"\n DEFAULT %@", defaultValue];
 			}
-            // *CHAR, *TEXT and *ENUM must be wrapped with single or double quotes for empty string and other default value. Expression are provided as is. TIMESTAMP and DATETIME must always be wrapped in quotes.
-            else if ([theRowType hasSuffix:@"CHAR"] || [theRowType hasSuffix:@"TEXT"] || [theRowType hasSuffix:@"ENUM"] || [theRowType isInArray:@[@"TIMESTAMP",@"DATETIME"]]) {
+            // *CHAR, *TEXT and *ENUM must be wrapped with single or double quotes for empty string and other default value. Expression are provided as is. TIMESTAMP, DATETIME and DATE must always be wrapped in quotes.
+            else if ([theRowType hasSuffix:@"CHAR"] || [theRowType hasSuffix:@"TEXT"] || [theRowType hasSuffix:@"ENUM"] || [theRowType isInArray:@[@"TIMESTAMP",@"DATETIME",@"DATE"]]) {
                 // If default value is not an expresion or a string, add quotes.
                 if (!defaultValueIsExpression && !defaultValueIsString)
                     [queryString appendFormat:@"\n DEFAULT %@", [mySQLConnection escapeAndQuoteString:defaultValue]];

--- a/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.h
+++ b/Source/Controllers/Preferences/Panes/SPEditorPreferencePane.h
@@ -56,9 +56,11 @@
 	IBOutlet NSMenuItem *saveThemeMenuItem;
 	
 	IBOutlet NSTableView *colorSettingTableView;
+	IBOutlet NSTableView *colorSettingDarkModeTableView;
 	IBOutlet NSMenu *themeSelectionMenu;
 	
 	NSArray *editorColors;
+	NSArray *editorDarkModeColors;
 	NSArray *editorNameForColors;
 	NSUInteger colorRow;
 	

--- a/Source/Controllers/Preferences/SPPreferenceController.m
+++ b/Source/Controllers/Preferences/SPPreferenceController.m
@@ -109,8 +109,13 @@
 			}
 		}
 	}
-	
-	[[self window] setMinSize:NSMakeSize(500, 450)];
+
+	CGFloat minWidthWindow = 700;
+	CGFloat minHeightContent = 526;
+	CGFloat minHeightTopBar = 85;
+  
+	[[self window] setMinSize:NSMakeSize(minWidthWindow, minHeightContent + minHeightTopBar)];
+	[[self window] setContentMinSize:NSMakeSize(minWidthWindow, minHeightContent)];
 	[[self window] setShowsResizeIndicator:YES];
 	
 	[toolbar setSelectedItemIdentifier:[preferencePane preferencePaneIdentifier]];
@@ -233,9 +238,6 @@
  */
 - (void)_resizeWindowForContentView:(NSView *)view
 {
-	// Handle expanding
-	[[self window] resizeForContentView:view];
-
 	// Add view
 	[self window].contentView = view;
 

--- a/Source/Interfaces/DBView.xib
+++ b/Source/Interfaces/DBView.xib
@@ -1343,11 +1343,6 @@
                                                                                                     <size key="maxSize" width="100000" height="10000000"/>
                                                                                                     <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                                                     <connections>
-                                                                                                        <binding destination="1907" name="textColor" keyPath="values.CustomQueryEditorTextColor" id="8258">
-                                                                                                            <dictionary key="options">
-                                                                                                                <string key="NSValueTransformerName">NSUnarchiveFromData</string>
-                                                                                                            </dictionary>
-                                                                                                        </binding>
                                                                                                         <outlet property="customQueryInstance" destination="134" id="8259"/>
                                                                                                         <outlet property="delegate" destination="134" id="8260"/>
                                                                                                         <outlet property="scrollView" destination="8251" id="8255"/>

--- a/Source/Interfaces/Preferences.xib
+++ b/Source/Interfaces/Preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -41,6 +41,7 @@
         </customObject>
         <customObject id="2144" userLabel="Editor" customClass="SPEditorPreferencePane">
             <connections>
+                <outlet property="colorSettingDarkModeTableView" destination="J5y-ix-ZdH" id="2182"/>
                 <outlet property="colorSettingTableView" destination="1685" id="2171"/>
                 <outlet property="colorThemeName" destination="1740" id="2161"/>
                 <outlet property="colorThemeNameLabel" destination="1738" id="2160"/>
@@ -83,7 +84,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenAuxiliary="YES"/>
             <rect key="contentRect" x="430" y="486" width="700" height="100"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="944"/>
             <value key="minSize" type="size" width="540" height="100"/>
             <value key="maxSize" type="size" width="1500" height="700"/>
             <value key="minFullScreenContentSize" type="size" width="540" height="100"/>
@@ -101,7 +102,7 @@
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="343" y="481" width="227" height="114"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="944"/>
             <value key="minSize" type="size" width="227" height="114"/>
             <value key="maxSize" type="size" width="247" height="124"/>
             <view key="contentView" id="1717">
@@ -205,7 +206,7 @@ Gw
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="343" y="370" width="264" height="234"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="944"/>
             <value key="minSize" type="size" width="264" height="225"/>
             <value key="maxSize" type="size" width="264" height="274"/>
             <view key="contentView" id="1757">
@@ -320,10 +321,10 @@ Gw
             <point key="canvasLocation" x="-364" y="159"/>
         </window>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="17" userLabel="General">
-            <rect key="frame" x="0.0" y="0.0" width="540" height="489"/>
+            <rect key="frame" x="0.0" y="0.0" width="540" height="482"/>
             <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="XRZ-IQ-R00">
-                    <rect key="frame" x="178" y="451" width="342" height="24"/>
+                    <rect key="frame" x="178" y="444" width="342" height="24"/>
                     <buttonCell key="cell" type="check" title="Prompt for confirmation before quitting" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="pLU-wO-HXa">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -336,19 +337,19 @@ Gw
                     </connections>
                 </button>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="FJw-vU-VgL">
-                    <rect key="frame" x="180" y="440" width="340" height="5"/>
+                    <rect key="frame" x="180" y="433" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="o4y-7V-ZEP"/>
                     </constraints>
                 </box>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1420">
-                    <rect key="frame" x="180" y="368" width="340" height="5"/>
+                    <rect key="frame" x="180" y="361" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="jHx-SA-a0F"/>
                     </constraints>
                 </box>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1419">
-                    <rect key="frame" x="18" y="340" width="154" height="20"/>
+                    <rect key="frame" x="18" y="333" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="8zj-eb-GHj"/>
                         <constraint firstAttribute="height" constant="20" id="GHh-gf-gj6"/>
@@ -360,10 +361,10 @@ Gw
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1418">
-                    <rect key="frame" x="177" y="335" width="347" height="27"/>
+                    <rect key="frame" x="177" y="328" width="347" height="27"/>
                     <popUpButtonCell key="cell" type="push" title="Last Used" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="1449" id="1422">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" title="OtherViews" id="1423">
                             <items>
                                 <menuItem title="Last Used" state="on" id="1449">
@@ -399,19 +400,19 @@ Gw
                     </connections>
                 </popUpButton>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="582">
-                    <rect key="frame" x="180" y="286" width="340" height="5"/>
+                    <rect key="frame" x="180" y="279" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="epJ-gi-vWC"/>
                     </constraints>
                 </box>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="581">
-                    <rect key="frame" x="180" y="327" width="340" height="5"/>
+                    <rect key="frame" x="180" y="320" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="Lfj-js-9td"/>
                     </constraints>
                 </box>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="947">
-                    <rect key="frame" x="178" y="232" width="342" height="24"/>
+                    <rect key="frame" x="178" y="225" width="342" height="24"/>
                     <buttonCell key="cell" type="check" title="Display comments in tables list" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="948">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -424,7 +425,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="hMm-gH-Xw4">
-                    <rect key="frame" x="178" y="208" width="342" height="24"/>
+                    <rect key="frame" x="178" y="201" width="342" height="24"/>
                     <buttonCell key="cell" type="check" title="Save query history individually" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="3B6-Jd-2pW">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -437,7 +438,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="957">
-                    <rect key="frame" x="178" y="256" width="342" height="24"/>
+                    <rect key="frame" x="178" y="249" width="342" height="24"/>
                     <buttonCell key="cell" type="check" title="Display vertical grid lines" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="958">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -450,7 +451,7 @@ Gw
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="bHb-uY-JgS">
-                    <rect key="frame" x="178" y="185" width="342" height="24"/>
+                    <rect key="frame" x="178" y="178" width="342" height="24"/>
                     <buttonCell key="cell" type="check" title="Display column types on content view" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Z7f-0u-a0e">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -463,7 +464,7 @@ Gw
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="577">
-                    <rect key="frame" x="18" y="299" width="154" height="20"/>
+                    <rect key="frame" x="18" y="292" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="2fJ-uV-yWE"/>
                         <constraint firstAttribute="width" constant="150" id="H3R-fZ-7pu"/>
@@ -475,7 +476,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1465">
-                    <rect key="frame" x="18" y="258" width="154" height="20"/>
+                    <rect key="frame" x="18" y="251" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="Pth-OX-OBR"/>
                         <constraint firstAttribute="height" constant="20" id="jzh-o6-wrC"/>
@@ -487,10 +488,10 @@ Gw
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="569">
-                    <rect key="frame" x="177" y="407" width="347" height="27"/>
+                    <rect key="frame" x="177" y="400" width="347" height="27"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" autoenablesItems="NO" id="570">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" title="OtherViews" autoenablesItems="NO" id="571"/>
                     </popUpButtonCell>
                     <constraints>
@@ -502,7 +503,7 @@ Gw
                     </connections>
                 </popUpButton>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="568">
-                    <rect key="frame" x="18" y="412" width="154" height="20"/>
+                    <rect key="frame" x="18" y="405" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="iwU-u3-PUC"/>
                         <constraint firstAttribute="height" constant="20" id="y3H-yc-8cM"/>
@@ -514,7 +515,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="567">
-                    <rect key="frame" x="178" y="379" width="342" height="24"/>
+                    <rect key="frame" x="178" y="372" width="342" height="24"/>
                     <buttonCell key="cell" type="check" title="Connect to default on startup" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="576">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -527,10 +528,10 @@ Gw
                     </connections>
                 </button>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="24" userLabel="Default Encoding Dropdown">
-                    <rect key="frame" x="177" y="294" width="347" height="27"/>
+                    <rect key="frame" x="177" y="287" width="347" height="27"/>
                     <popUpButtonCell key="cell" type="push" title="Autodetect" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="50" id="25">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" title="OtherViews" id="26">
                             <items>
                                 <menuItem title="Autodetect" state="on" id="50"/>
@@ -590,13 +591,13 @@ Gw
                     </connections>
                 </popUpButton>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="784">
-                    <rect key="frame" x="180" y="176" width="340" height="5"/>
+                    <rect key="frame" x="180" y="169" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="vus-7q-stB"/>
                     </constraints>
                 </box>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="790">
-                    <rect key="frame" x="398" y="154" width="124" height="14"/>
+                    <rect key="frame" x="398" y="139" width="124" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="nGd-yZ-I7g"/>
                     </constraints>
@@ -607,7 +608,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <textField toolTip="Enter the maximum number of entries to remember in the Custom Query query history, from 0 to 99" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="787">
-                    <rect key="frame" x="180" y="150" width="215" height="22"/>
+                    <rect key="frame" x="180" y="139" width="215" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="1Oz-rT-AdX"/>
                     </constraints>
@@ -627,7 +628,7 @@ Gw
                     </connections>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="785">
-                    <rect key="frame" x="18" y="150" width="154" height="20"/>
+                    <rect key="frame" x="18" y="139" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="iNE-8S-1ug"/>
                         <constraint firstAttribute="height" constant="20" id="m9i-Kw-gLk"/>
@@ -638,20 +639,20 @@ Gw
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <box boxType="custom" borderType="none" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="7J9-Yp-qMZ">
-                    <rect key="frame" x="0.0" y="101" width="540" height="41"/>
+                <box verticalCompressionResistancePriority="450" boxType="custom" borderType="none" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="7J9-Yp-qMZ">
+                    <rect key="frame" x="0.0" y="87" width="540" height="42"/>
                     <view key="contentView" id="8QO-1r-5jB">
-                        <rect key="frame" x="0.0" y="0.0" width="540" height="41"/>
+                        <rect key="frame" x="0.0" y="0.0" width="540" height="42"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="m2t-AW-wZp">
-                                <rect key="frame" x="180" y="38" width="340" height="5"/>
+                                <rect key="frame" x="180" y="39" width="340" height="5"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="w2r-U9-xzl"/>
                                 </constraints>
                             </box>
                             <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zSn-Pq-u9O">
-                                <rect key="frame" x="18" y="10" width="154" height="20"/>
+                                <rect key="frame" x="18" y="11" width="154" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="KTX-VG-c9A"/>
                                     <constraint firstAttribute="width" constant="150" id="NuT-p2-IHy"/>
@@ -663,7 +664,7 @@ Gw
                                 </textFieldCell>
                             </textField>
                             <textField hidden="YES" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="A54-fI-5jD">
-                                <rect key="frame" x="398" y="12" width="124" height="16"/>
+                                <rect key="frame" x="398" y="13" width="124" height="16"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="oJR-dz-ggb"/>
                                 </constraints>
@@ -674,10 +675,10 @@ Gw
                                 </textFieldCell>
                             </textField>
                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YpU-KB-oKj">
-                                <rect key="frame" x="177" y="5" width="222" height="27"/>
+                                <rect key="frame" x="177" y="6" width="222" height="27"/>
                                 <popUpButtonCell key="cell" type="push" title="Light" bezelStyle="rounded" alignment="left" lineBreakMode="clipping" enabled="NO" state="on" borderStyle="border" tag="1" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="eKV-qw-xZ9" id="qEs-4C-bPo">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="menu"/>
+                                    <font key="font" metaFont="message"/>
                                     <menu key="menu" title="OtherViews" id="kke-hm-U3J">
                                         <items>
                                             <menuItem title="Light" state="on" tag="1" id="eKV-qw-xZ9">
@@ -709,10 +710,10 @@ Gw
                             <constraint firstItem="YpU-KB-oKj" firstAttribute="leading" secondItem="m2t-AW-wZp" secondAttribute="leading" id="6li-My-U6Q"/>
                             <constraint firstItem="A54-fI-5jD" firstAttribute="leading" secondItem="YpU-KB-oKj" secondAttribute="trailing" constant="5" id="ES9-bt-d8F"/>
                             <constraint firstItem="YpU-KB-oKj" firstAttribute="centerY" secondItem="zSn-Pq-u9O" secondAttribute="centerY" id="NhH-JG-F7e"/>
+                            <constraint firstItem="zSn-Pq-u9O" firstAttribute="centerY" secondItem="8QO-1r-5jB" secondAttribute="centerY" id="RMA-62-BWK"/>
                             <constraint firstItem="A54-fI-5jD" firstAttribute="centerY" secondItem="zSn-Pq-u9O" secondAttribute="centerY" id="RSy-6K-GNB"/>
                             <constraint firstItem="m2t-AW-wZp" firstAttribute="top" secondItem="8QO-1r-5jB" secondAttribute="top" id="cjR-xY-u0O"/>
                             <constraint firstItem="YpU-KB-oKj" firstAttribute="leading" secondItem="zSn-Pq-u9O" secondAttribute="trailing" constant="10" id="jbv-tQ-cWP"/>
-                            <constraint firstAttribute="bottom" secondItem="YpU-KB-oKj" secondAttribute="bottom" constant="9" id="k6U-6l-mIv"/>
                             <constraint firstItem="YpU-KB-oKj" firstAttribute="top" secondItem="m2t-AW-wZp" secondAttribute="bottom" constant="9" id="qvF-s5-WKM"/>
                             <constraint firstAttribute="trailing" secondItem="A54-fI-5jD" secondAttribute="trailing" constant="20" id="wZU-Cc-BI5"/>
                             <constraint firstItem="zSn-Pq-u9O" firstAttribute="leading" secondItem="8QO-1r-5jB" secondAttribute="leading" constant="20" id="wsp-nB-hpQ"/>
@@ -720,19 +721,19 @@ Gw
                     </view>
                 </box>
                 <box boxType="custom" borderType="none" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="F3U-SQ-W2d">
-                    <rect key="frame" x="0.0" y="70" width="540" height="31"/>
+                    <rect key="frame" x="0.0" y="54" width="540" height="33"/>
                     <view key="contentView" id="typ-rs-Tmp">
-                        <rect key="frame" x="0.0" y="0.0" width="540" height="31"/>
+                        <rect key="frame" x="0.0" y="0.0" width="540" height="33"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="zo3-G0-Lj6">
-                                <rect key="frame" x="180" y="28" width="340" height="5"/>
+                            <box autoresizesSubviews="NO" horizontalHuggingPriority="245" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="zo3-G0-Lj6">
+                                <rect key="frame" x="180" y="30" width="340" height="5"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="esL-SH-GKA"/>
                                 </constraints>
                             </box>
                             <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lsf-qy-07D">
-                                <rect key="frame" x="18" y="0.0" width="154" height="20"/>
+                                <rect key="frame" x="18" y="1" width="154" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="1mZ-E2-f6l"/>
                                     <constraint firstAttribute="width" constant="150" id="Wic-EO-nDe"/>
@@ -743,85 +744,81 @@ Gw
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yhD-8W-lrG" customClass="SPFontPreviewTextField">
-                                <rect key="frame" x="180" y="-1" width="215" height="22"/>
+                            <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yhD-8W-lrG" customClass="SPFontPreviewTextField">
+                                <rect key="frame" x="180" y="0.0" width="254" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="DcB-XL-DMt"/>
                                 </constraints>
-                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="cY2-s3-8OD">
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="cY2-s3-8OD">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zBm-kj-adR">
-                                <rect key="frame" x="393" y="-7" width="134" height="32"/>
+                                <rect key="frame" x="432" y="-6" width="91" height="32"/>
                                 <buttonCell key="cell" type="push" title="Change…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="V62-2t-uwh">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="I6V-7f-rdZ"/>
-                                    <constraint firstAttribute="height" constant="20" id="d3f-DE-oUX"/>
-                                </constraints>
                                 <connections>
                                     <action selector="showGlobalResultFontPanel:" target="2074" id="kbT-Z1-jUN"/>
                                 </connections>
                             </button>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="zBm-kj-adR" secondAttribute="trailing" constant="20" id="BH4-9V-9OU"/>
-                            <constraint firstItem="zBm-kj-adR" firstAttribute="centerY" secondItem="lsf-qy-07D" secondAttribute="centerY" id="Kpt-iW-R3s"/>
-                            <constraint firstItem="yhD-8W-lrG" firstAttribute="leading" secondItem="zo3-G0-Lj6" secondAttribute="leading" id="QIm-KO-shv"/>
-                            <constraint firstItem="zBm-kj-adR" firstAttribute="leading" secondItem="yhD-8W-lrG" secondAttribute="trailing" constant="5" id="VdS-XF-ama"/>
-                            <constraint firstItem="yhD-8W-lrG" firstAttribute="top" secondItem="zo3-G0-Lj6" secondAttribute="bottom" constant="9" id="VoI-wv-LCe"/>
+                            <constraint firstAttribute="trailing" secondItem="zo3-G0-Lj6" secondAttribute="trailing" constant="20" id="9Ie-Oy-RBS"/>
+                            <constraint firstItem="zo3-G0-Lj6" firstAttribute="leading" secondItem="yhD-8W-lrG" secondAttribute="leading" id="EhC-WN-Bfg"/>
+                            <constraint firstItem="lsf-qy-07D" firstAttribute="centerY" secondItem="yhD-8W-lrG" secondAttribute="centerY" id="Kpt-iW-R3s"/>
+                            <constraint firstItem="zBm-kj-adR" firstAttribute="leading" secondItem="yhD-8W-lrG" secondAttribute="trailing" constant="5" id="OR1-UM-TBa"/>
+                            <constraint firstItem="yhD-8W-lrG" firstAttribute="top" secondItem="zo3-G0-Lj6" secondAttribute="bottom" constant="10" id="VoI-wv-LCe"/>
                             <constraint firstItem="lsf-qy-07D" firstAttribute="leading" secondItem="typ-rs-Tmp" secondAttribute="leading" constant="20" id="X7b-sv-ZtT"/>
-                            <constraint firstItem="yhD-8W-lrG" firstAttribute="centerY" secondItem="lsf-qy-07D" secondAttribute="centerY" id="j3q-mR-FbZ"/>
+                            <constraint firstItem="zBm-kj-adR" firstAttribute="baseline" secondItem="yhD-8W-lrG" secondAttribute="firstBaseline" id="elY-tl-e23"/>
                             <constraint firstItem="zo3-G0-Lj6" firstAttribute="top" secondItem="typ-rs-Tmp" secondAttribute="top" id="j8K-Vy-xA6"/>
+                            <constraint firstAttribute="trailing" secondItem="zBm-kj-adR" secondAttribute="trailing" constant="24" id="qg5-Ue-1es"/>
+                            <constraint firstAttribute="bottom" secondItem="zBm-kj-adR" secondAttribute="bottom" constant="1" id="rBu-ze-B95"/>
                             <constraint firstItem="yhD-8W-lrG" firstAttribute="leading" secondItem="lsf-qy-07D" secondAttribute="trailing" constant="10" id="rDw-N8-wjH"/>
-                            <constraint firstAttribute="trailing" secondItem="zo3-G0-Lj6" secondAttribute="trailing" constant="20" id="sem-qe-8r6"/>
-                            <constraint firstAttribute="bottom" secondItem="zBm-kj-adR" secondAttribute="bottom" id="ste-5b-NEm"/>
                         </constraints>
                     </view>
                 </box>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gcQ-a7-Kqd">
-                    <rect key="frame" x="18" y="29" width="154" height="20"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="150" id="UXx-vH-pTm"/>
-                        <constraint firstAttribute="height" constant="20" id="cZz-2P-Xzw"/>
-                    </constraints>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Analytics" id="6mk-ml-lFe">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="2aR-JM-Lbr">
-                    <rect key="frame" x="178" y="27" width="342" height="24"/>
+                    <rect key="frame" x="178" y="14" width="342" height="20"/>
                     <buttonCell key="cell" type="check" title="Share anonymized usage analytics with developers" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="mZ1-oa-LuT">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <constraints>
-                        <constraint firstAttribute="height" constant="22" id="f9S-3k-CY3"/>
+                        <constraint firstAttribute="height" constant="18" id="f9S-3k-CY3"/>
                     </constraints>
                     <connections>
                         <binding destination="117" name="value" keyPath="values.SaveApplicationUsageAnalytics" id="PGy-Vc-fm7"/>
                     </connections>
                 </button>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="XAX-zM-z61">
-                    <rect key="frame" x="180" y="57" width="340" height="5"/>
+                    <rect key="frame" x="180" y="41" width="340" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="GuS-Im-MmS"/>
                     </constraints>
                 </box>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NBD-nG-VYi">
-                    <rect key="frame" x="18" y="453" width="154" height="20"/>
+                    <rect key="frame" x="18" y="446" width="154" height="20"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="150" id="I93-gu-1Cg"/>
                         <constraint firstAttribute="height" constant="20" id="Iqw-5P-eDM"/>
                     </constraints>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Application:" id="4Ci-Qa-l0l">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gcQ-a7-Kqd">
+                    <rect key="frame" x="18" y="14" width="154" height="20"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="150" id="UXx-vH-pTm"/>
+                        <constraint firstAttribute="height" constant="20" id="cZz-2P-Xzw"/>
+                    </constraints>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Analytics" id="6mk-ml-lFe">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -838,7 +835,7 @@ Gw
                 <constraint firstItem="1418" firstAttribute="top" secondItem="1420" secondAttribute="bottom" constant="9" id="6hc-io-AZE"/>
                 <constraint firstItem="582" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="8xS-ld-NA8"/>
                 <constraint firstAttribute="trailing" secondItem="F3U-SQ-W2d" secondAttribute="trailing" id="93x-P2-EBJ"/>
-                <constraint firstItem="787" firstAttribute="top" secondItem="784" secondAttribute="bottom" constant="6" id="9Mn-N1-aSY"/>
+                <constraint firstItem="787" firstAttribute="top" secondItem="784" secondAttribute="bottom" constant="10" id="9Mn-N1-aSY"/>
                 <constraint firstItem="957" firstAttribute="centerY" secondItem="1465" secondAttribute="centerY" id="9lb-a9-Siy"/>
                 <constraint firstItem="790" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="9vT-H7-QwT"/>
                 <constraint firstItem="567" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="AIy-lZ-vhT"/>
@@ -846,13 +843,14 @@ Gw
                 <constraint firstItem="787" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="Bbt-nF-FyG"/>
                 <constraint firstItem="gcQ-a7-Kqd" firstAttribute="leading" secondItem="17" secondAttribute="leading" constant="20" id="Bfj-MK-Pq1"/>
                 <constraint firstItem="7J9-Yp-qMZ" firstAttribute="leading" secondItem="17" secondAttribute="leading" id="ES6-K4-QTe"/>
-                <constraint firstItem="F3U-SQ-W2d" firstAttribute="top" secondItem="7J9-Yp-qMZ" secondAttribute="bottom" id="G6O-Ql-CaV"/>
+                <constraint firstItem="zo3-G0-Lj6" firstAttribute="top" secondItem="YpU-KB-oKj" secondAttribute="bottom" constant="10" id="F3n-5E-PcZ"/>
                 <constraint firstItem="567" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="GpK-3f-RXE"/>
                 <constraint firstItem="790" firstAttribute="top" secondItem="bHb-uY-JgS" secondAttribute="bottom" constant="18" id="GxQ-uz-O2B"/>
                 <constraint firstItem="1418" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="H5T-g6-PU5"/>
                 <constraint firstItem="947" firstAttribute="top" secondItem="957" secondAttribute="bottom" constant="2" id="HC4-0f-RPy"/>
                 <constraint firstItem="24" firstAttribute="top" secondItem="581" secondAttribute="bottom" constant="9" id="HLY-rd-SfS"/>
                 <constraint firstItem="947" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="IYp-aC-TVp"/>
+                <constraint firstAttribute="bottom" secondItem="2aR-JM-Lbr" secondAttribute="bottom" constant="15" id="Ib8-lR-62P"/>
                 <constraint firstItem="F3U-SQ-W2d" firstAttribute="leading" secondItem="17" secondAttribute="leading" id="Im0-9V-68O"/>
                 <constraint firstItem="784" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="JVt-FZ-AWU"/>
                 <constraint firstItem="785" firstAttribute="leading" secondItem="17" secondAttribute="leading" constant="20" id="JuX-m1-yDO"/>
@@ -866,15 +864,14 @@ Gw
                 <constraint firstItem="581" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="Ogb-QW-1uw"/>
                 <constraint firstItem="957" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="Orb-W6-T4J"/>
                 <constraint firstItem="957" firstAttribute="top" secondItem="582" secondAttribute="bottom" constant="9" id="PIX-w3-EeM"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="F3U-SQ-W2d" secondAttribute="bottom" constant="70" id="PYb-fK-u5u"/>
                 <constraint firstItem="577" firstAttribute="leading" secondItem="17" secondAttribute="leading" constant="20" id="QFi-wi-jse"/>
                 <constraint firstItem="FJw-vU-VgL" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="Quq-iv-5iD"/>
-                <constraint firstItem="7J9-Yp-qMZ" firstAttribute="top" secondItem="787" secondAttribute="bottom" constant="8" id="VDV-pe-DL0"/>
+                <constraint firstItem="7J9-Yp-qMZ" firstAttribute="top" secondItem="787" secondAttribute="bottom" constant="10" id="VDV-pe-DL0"/>
                 <constraint firstItem="784" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="VOf-4w-xgO"/>
                 <constraint firstItem="bHb-uY-JgS" firstAttribute="leading" secondItem="784" secondAttribute="leading" id="W4N-5b-uqF"/>
                 <constraint firstItem="569" firstAttribute="trailing" secondItem="XRZ-IQ-R00" secondAttribute="trailing" id="WCa-as-XxN"/>
                 <constraint firstItem="1420" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="WiS-oj-FT3"/>
-                <constraint firstItem="2aR-JM-Lbr" firstAttribute="top" secondItem="XAX-zM-z61" secondAttribute="bottom" constant="9" id="XYl-mN-TCg"/>
+                <constraint firstItem="2aR-JM-Lbr" firstAttribute="top" secondItem="XAX-zM-z61" secondAttribute="bottom" constant="10" id="XYl-mN-TCg"/>
                 <constraint firstItem="957" firstAttribute="leading" secondItem="569" secondAttribute="leading" id="ZaW-If-0qM"/>
                 <constraint firstItem="582" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="aCS-ZA-klL"/>
                 <constraint firstItem="2aR-JM-Lbr" firstAttribute="centerY" secondItem="gcQ-a7-Kqd" secondAttribute="centerY" id="awJ-f0-Gff"/>
@@ -902,10 +899,10 @@ Gw
                 <constraint firstItem="582" firstAttribute="top" secondItem="24" secondAttribute="bottom" constant="9" id="x21-dW-TG6"/>
                 <constraint firstItem="2aR-JM-Lbr" firstAttribute="trailing" secondItem="569" secondAttribute="trailing" id="xnW-28-sTv"/>
                 <constraint firstItem="784" firstAttribute="top" secondItem="hMm-gH-Xw4" secondAttribute="bottom" constant="30" id="xsB-vw-oOb"/>
-                <constraint firstItem="XAX-zM-z61" firstAttribute="top" secondItem="yhD-8W-lrG" secondAttribute="bottom" constant="9" id="yri-Jh-GCb"/>
+                <constraint firstItem="XAX-zM-z61" firstAttribute="top" secondItem="yhD-8W-lrG" secondAttribute="bottom" constant="10" id="yri-Jh-GCb"/>
                 <constraint firstItem="1419" firstAttribute="leading" secondItem="17" secondAttribute="leading" constant="20" id="zZB-QF-61w"/>
             </constraints>
-            <point key="canvasLocation" x="-52" y="1082"/>
+            <point key="canvasLocation" x="-52" y="1092"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="512" userLabel="Tables">
             <rect key="frame" x="0.0" y="0.0" width="540" height="359"/>
@@ -1119,7 +1116,7 @@ Gw
                     <rect key="frame" x="177" y="61" width="347" height="27"/>
                     <popUpButtonCell key="cell" type="push" title="Only use additional queries for small tables" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="1474" id="1471">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" title="OtherViews" id="1472">
                             <items>
                                 <menuItem title="Never use additional queries for table row counts" id="1473"/>
@@ -1417,7 +1414,7 @@ Gw
                 <constraint firstItem="1143" firstAttribute="top" secondItem="1156" secondAttribute="bottom" constant="12" id="Wht-jN-U7j"/>
                 <constraint firstItem="1152" firstAttribute="leading" secondItem="1148" secondAttribute="leading" id="ZOt-Le-XIK"/>
                 <constraint firstItem="1150" firstAttribute="leading" secondItem="1148" secondAttribute="leading" id="aIy-wz-dZg"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="1154" secondAttribute="bottom" constant="15" id="arD-8s-VKF"/>
+                <constraint firstAttribute="bottom" secondItem="1154" secondAttribute="bottom" constant="15" id="arD-8s-VKF"/>
                 <constraint firstItem="1150" firstAttribute="top" secondItem="1152" secondAttribute="bottom" constant="9" id="eTF-EK-Z2n"/>
                 <constraint firstItem="1154" firstAttribute="trailing" secondItem="1156" secondAttribute="trailing" id="gDz-zf-ZSa"/>
                 <constraint firstItem="1152" firstAttribute="top" secondItem="1148" secondAttribute="bottom" constant="9" id="pKc-k0-Baa"/>
@@ -1431,10 +1428,10 @@ Gw
                 <constraint firstItem="1148" firstAttribute="top" secondItem="1143" secondAttribute="bottom" constant="6" id="wbi-xL-mtz"/>
                 <constraint firstItem="wue-rM-fp8" firstAttribute="top" secondItem="nmG-Wb-i0O" secondAttribute="bottom" constant="9" id="x4k-LN-e54"/>
             </constraints>
-            <point key="canvasLocation" x="751" y="166.5"/>
+            <point key="canvasLocation" x="712" y="124"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="641" userLabel="Network">
-            <rect key="frame" x="0.0" y="-10" width="540" height="410"/>
+            <rect key="frame" x="0.0" y="0.0" width="540" height="410"/>
             <subviews>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="681">
                     <rect key="frame" x="180" y="362" width="340" height="5"/>
@@ -1647,7 +1644,7 @@ Gw
                     <rect key="frame" x="177" y="261" width="347" height="27"/>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="X7v-6X-VbB" id="KPx-1M-u3e">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="X6f-Ih-yPF">
                             <items>
                                 <menuItem title="Item 1" state="on" id="X7v-6X-VbB"/>
@@ -1695,7 +1692,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     <rect key="frame" x="177" y="226" width="347" height="27"/>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="geP-YV-B0g" id="hmJ-F4-sdq">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="jFV-QJ-gOA">
                             <items>
                                 <menuItem title="Item 1" state="on" id="geP-YV-B0g"/>
@@ -1773,20 +1770,20 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
             <point key="canvasLocation" x="732" y="551"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="802" userLabel="Editor">
-            <rect key="frame" x="0.0" y="0.0" width="540" height="487"/>
+            <rect key="frame" x="0.0" y="0.0" width="656" height="503"/>
             <userGuides>
-                <userLayoutGuide location="146" affinity="minX"/>
-                <userLayoutGuide location="315" affinity="minX"/>
+                <userLayoutGuide location="147" affinity="minX"/>
+                <userLayoutGuide location="316" affinity="minX"/>
             </userGuides>
             <subviews>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1085">
-                    <rect key="frame" x="20" y="438" width="500" height="5"/>
+                    <rect key="frame" x="20" y="445" width="616" height="5"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="mJZ-MM-v9M"/>
                     </constraints>
                 </box>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1083">
-                    <rect key="frame" x="472" y="256" width="50" height="14"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1083">
+                    <rect key="frame" x="584" y="257" width="50" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="46" id="4mD-hS-s3t"/>
                     </constraints>
@@ -1799,8 +1796,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="enabled" keyPath="values.CustomQueryUpdateAutoHelp" id="1112"/>
                     </connections>
                 </textField>
-                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1046">
-                    <rect key="frame" x="458" y="251" width="15" height="22"/>
+                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1046">
+                    <rect key="frame" x="570" y="252" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="EEE-Hl-ffx"/>
                         <constraint firstAttribute="width" constant="11" id="teM-Rz-MWp"/>
@@ -1814,8 +1811,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="enabled" keyPath="values.CustomQueryUpdateAutoHelp" id="1110"/>
                     </connections>
                 </stepper>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1045">
-                    <rect key="frame" x="279" y="247" width="59" height="22"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1045">
+                    <rect key="frame" x="484" y="248" width="59" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="J1h-3t-Frd"/>
                         <constraint firstAttribute="width" constant="55" id="wmw-DW-vkB"/>
@@ -1829,8 +1826,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="enabled" keyPath="values.CustomQueryUpdateAutoHelp" id="1108"/>
                     </connections>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1044">
-                    <rect key="frame" x="341" y="252" width="118" height="22"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1044">
+                    <rect key="frame" x="546" y="253" width="25" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="7Gy-54-e6x"/>
                     </constraints>
@@ -1851,8 +1848,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="enabled" keyPath="values.CustomQueryUpdateAutoHelp" id="1109"/>
                     </connections>
                 </textField>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="1128">
-                    <rect key="frame" x="259" y="224" width="261" height="24"/>
+                <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1128">
+                    <rect key="frame" x="430" y="225" width="202" height="24"/>
                     <buttonCell key="cell" type="check" title="Highlight current query" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="1129">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1864,8 +1861,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryHighlightCurrentQuery" id="1134"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="1042">
-                    <rect key="frame" x="259" y="315" width="261" height="24"/>
+                <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1042">
+                    <rect key="frame" x="430" y="316" width="202" height="24"/>
                     <buttonCell key="cell" type="check" title="Auto uppercase keywords" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="1052">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1877,8 +1874,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryAutoUppercaseKeywords" id="1093"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="1041">
-                    <rect key="frame" x="259" y="273" width="261" height="35"/>
+                <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1041">
+                    <rect key="frame" x="430" y="274" width="202" height="35"/>
                     <buttonCell key="cell" type="check" title="Update help while typing" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1053">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1890,8 +1887,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryUpdateAutoHelp" id="1107"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="1040">
-                    <rect key="frame" x="259" y="346" width="261" height="24"/>
+                <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1040">
+                    <rect key="frame" x="430" y="347" width="202" height="24"/>
                     <buttonCell key="cell" type="check" title="Auto pair characters" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="1054">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1903,8 +1900,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryAutoPairCharacters" id="1096"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="1039">
-                    <rect key="frame" x="259" y="408" width="261" height="24"/>
+                <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1039">
+                    <rect key="frame" x="430" y="409" width="202" height="24"/>
                     <buttonCell key="cell" type="check" title="Indent new lines" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="1055">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1918,7 +1915,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1037" customClass="SPFontPreviewTextField">
-                    <rect key="frame" x="106" y="449" width="200" height="22"/>
+                    <rect key="frame" x="110" y="468" width="312" height="22"/>
                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="1057">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -1926,7 +1923,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1036">
-                    <rect key="frame" x="309" y="443" width="114" height="32"/>
+                    <rect key="frame" x="425" y="462" width="114" height="32"/>
                     <buttonCell key="cell" type="push" title="Select…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1058">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1939,9 +1936,9 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1034">
-                    <rect key="frame" x="18" y="453" width="82" height="16"/>
+                    <rect key="frame" x="18" y="471" width="86" height="16"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="78" id="IcF-dQ-kV5"/>
+                        <constraint firstAttribute="width" constant="82" id="IcF-dQ-kV5"/>
                     </constraints>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Font:" id="1060">
                         <font key="font" metaFont="system"/>
@@ -1987,64 +1984,6 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <constraint firstAttribute="height" constant="24" id="5dQ-lD-em1"/>
                     </constraints>
                 </popUpButton>
-                <scrollView horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1682">
-                    <rect key="frame" x="20" y="49" width="231" height="382"/>
-                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oEY-Qs-g9y">
-                        <rect key="frame" x="1" y="1" width="229" height="380"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="20" id="1685">
-                                <rect key="frame" x="0.0" y="0.0" width="229" height="380"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <size key="intercellSpacing" width="3" height="2"/>
-                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
-                                <tableColumns>
-                                    <tableColumn identifier="name" width="194" minWidth="40" maxWidth="10000" id="1687">
-                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
-                                        </tableHeaderCell>
-                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" allowsUndo="NO" alignment="left" title="Text Cell" allowsEditingTextAttributes="YES" id="1690">
-                                            <font key="font" metaFont="system"/>
-                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                        </textFieldCell>
-                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                    </tableColumn>
-                                    <tableColumn identifier="color" editable="NO" width="20" minWidth="20" maxWidth="20" id="1688">
-                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
-                                        </tableHeaderCell>
-                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="1689">
-                                            <font key="font" metaFont="system"/>
-                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                        </textFieldCell>
-                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                    </tableColumn>
-                                </tableColumns>
-                                <connections>
-                                    <outlet property="dataSource" destination="2144" id="2172"/>
-                                    <outlet property="delegate" destination="2144" id="2173"/>
-                                </connections>
-                            </tableView>
-                        </subviews>
-                        <nil key="backgroundColor"/>
-                    </clipView>
-                    <constraints>
-                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Fuh-SQ-jA3"/>
-                    </constraints>
-                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="1684">
-                        <rect key="frame" x="-100" y="-100" width="223" height="15"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </scroller>
-                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="1683">
-                        <rect key="frame" x="-100" y="-100" width="15" height="102"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </scroller>
-                </scrollView>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1738">
                     <rect key="frame" x="47" y="20" width="84" height="14"/>
                     <constraints>
@@ -2057,7 +1996,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </textFieldCell>
                 </textField>
                 <textField toolTip="The name of the current set color theme" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1740">
-                    <rect key="frame" x="132" y="20" width="121" height="14"/>
+                    <rect key="frame" x="132" y="20" width="69" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="theme name" id="1741">
                         <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -2074,8 +2013,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         </binding>
                     </connections>
                 </textField>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="2185">
-                    <rect key="frame" x="259" y="377" width="97" height="24"/>
+                <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2185">
+                    <rect key="frame" x="430" y="378" width="97" height="24"/>
                     <buttonCell key="cell" type="check" title="Soft indent:" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="2186">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -2087,8 +2026,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQuerySoftIndent" id="2200"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2188">
-                    <rect key="frame" x="361" y="378" width="147" height="22"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2188">
+                    <rect key="frame" x="532" y="379" width="88" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="VGh-Jf-FAt"/>
                     </constraints>
@@ -2106,8 +2045,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQuerySoftIndentWidth" id="2209"/>
                     </connections>
                 </textField>
-                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2196">
-                    <rect key="frame" x="507" y="377" width="15" height="22"/>
+                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2196">
+                    <rect key="frame" x="619" y="378" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="11" id="Epk-vt-fev"/>
                         <constraint firstAttribute="height" constant="16" id="fyK-95-4bF"/>
@@ -2120,8 +2059,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQuerySoftIndentWidth" id="2205"/>
                     </connections>
                 </stepper>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="xIN-qP-ogl">
-                    <rect key="frame" x="259" y="193" width="261" height="24"/>
+                <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xIN-qP-ogl">
+                    <rect key="frame" x="430" y="194" width="202" height="24"/>
                     <buttonCell key="cell" type="check" title="Syntax highlighting" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="VHx-Tf-Rw2">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -2133,8 +2072,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryEnableSyntaxHighlighting" id="kJw-7M-n52"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UnY-1b-NTN">
-                    <rect key="frame" x="259" y="162" width="261" height="24"/>
+                <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UnY-1b-NTN">
+                    <rect key="frame" x="430" y="163" width="202" height="24"/>
                     <buttonCell key="cell" type="check" title="Bracket highlighting" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="vxK-rA-lkM">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -2149,8 +2088,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryEnableBracketHighlighting" id="635-un-YeG"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1517">
-                    <rect key="frame" x="472" y="109" width="50" height="14"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1517">
+                    <rect key="frame" x="584" y="110" width="50" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="46" id="Wt0-DH-0yD"/>
                     </constraints>
@@ -2163,8 +2102,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="enabled" keyPath="values.CustomQueryUpdateAutoHelp" id="1534"/>
                     </connections>
                 </textField>
-                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1518">
-                    <rect key="frame" x="458" y="104" width="15" height="22"/>
+                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1518">
+                    <rect key="frame" x="570" y="105" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="UHj-Wq-xiC"/>
                         <constraint firstAttribute="width" constant="11" id="nHg-43-jBJ"/>
@@ -2178,8 +2117,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryAutoCompleteDelay" id="1540"/>
                     </connections>
                 </stepper>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1519">
-                    <rect key="frame" x="279" y="100" width="59" height="22"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1519">
+                    <rect key="frame" x="484" y="101" width="59" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="6rD-Fb-Wtt"/>
                         <constraint firstAttribute="width" constant="55" id="sCD-jX-6bG"/>
@@ -2193,8 +2132,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="enabled" keyPath="values.CustomQueryUpdateAutoHelp" id="1535"/>
                     </connections>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1520">
-                    <rect key="frame" x="341" y="105" width="118" height="22"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1520">
+                    <rect key="frame" x="546" y="106" width="25" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="UbU-HI-GT2"/>
                     </constraints>
@@ -2215,8 +2154,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryAutoCompleteDelay" id="1538"/>
                     </connections>
                 </textField>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="1521">
-                    <rect key="frame" x="259" y="131" width="261" height="24"/>
+                <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1521">
+                    <rect key="frame" x="430" y="132" width="202" height="24"/>
                     <buttonCell key="cell" type="check" title="Auto-Completion" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1522">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -2228,8 +2167,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryAutoComplete" id="1537"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="q6h-n2-3a8">
-                    <rect key="frame" x="259" y="77" width="261" height="24"/>
+                <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q6h-n2-3a8">
+                    <rect key="frame" x="430" y="78" width="202" height="24"/>
                     <buttonCell key="cell" type="check" title="Complete with backticks" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="vGo-VU-lIt">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -2241,8 +2180,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.SPCustomQueryEditorCompleteWithBackticks" id="ZhP-mB-7aF"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="1542">
-                    <rect key="frame" x="259" y="46" width="261" height="24"/>
+                <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1542">
+                    <rect key="frame" x="430" y="47" width="202" height="24"/>
                     <buttonCell key="cell" type="check" title="Insert function arguments" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1543">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -2254,8 +2193,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryFunctionCompletionInsertsArguments" id="1545"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1499">
-                    <rect key="frame" x="259" y="18" width="97" height="20"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1499">
+                    <rect key="frame" x="430" y="19" width="97" height="20"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="OHa-nn-g2y"/>
                     </constraints>
@@ -2265,8 +2204,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1505">
-                    <rect key="frame" x="359" y="17" width="149" height="22"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1505">
+                    <rect key="frame" x="530" y="18" width="90" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="VkS-BX-Qdr"/>
                     </constraints>
@@ -2284,8 +2223,8 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <binding destination="117" name="value" keyPath="values.CustomQueryEditorTabStopWidth" id="1511"/>
                     </connections>
                 </textField>
-                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1497">
-                    <rect key="frame" x="507" y="16" width="15" height="22"/>
+                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1497">
+                    <rect key="frame" x="619" y="17" width="15" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="11" id="kU9-CG-jyc"/>
                         <constraint firstAttribute="height" constant="16" id="ua9-l2-nxz"/>
@@ -2299,7 +2238,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                     </connections>
                 </stepper>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="v54-2I-2wr">
-                    <rect key="frame" x="421" y="443" width="96" height="32"/>
+                    <rect key="frame" x="537" y="462" width="96" height="32"/>
                     <buttonCell key="cell" type="push" title="Reset" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ixc-ll-0TU">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -2311,11 +2250,150 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                         <action selector="resetSystemFont:" target="2144" id="xfA-aq-TbG"/>
                     </connections>
                 </button>
+                <tabView drawsBackground="NO" allowsTruncatedLabels="NO" initialItem="M8f-gQ-PcT" id="0jC-UV-cbM">
+                    <rect key="frame" x="13" y="58" width="380" height="380"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                    <tabViewItems>
+                        <tabViewItem label="Light" identifier="" id="M8f-gQ-PcT">
+                            <view key="view" id="efu-Lk-9wv">
+                                <rect key="frame" x="10" y="33" width="360" height="334"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <subviews>
+                                    <scrollView horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" id="1682">
+                                        <rect key="frame" x="10" y="8" width="340" height="330"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oEY-Qs-g9y">
+                                            <rect key="frame" x="1" y="1" width="338" height="328"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <subviews>
+                                                <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="20" id="1685">
+                                                    <rect key="frame" x="0.0" y="0.0" width="338" height="328"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                    <size key="intercellSpacing" width="3" height="2"/>
+                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                                    <tableColumns>
+                                                        <tableColumn identifier="name" width="303" minWidth="40" maxWidth="10000" id="1687">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" allowsUndo="NO" alignment="left" title="Text Cell" allowsEditingTextAttributes="YES" id="1690">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                        </tableColumn>
+                                                        <tableColumn identifier="color" editable="NO" width="20" minWidth="20" maxWidth="20" id="1688">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="1689">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                        </tableColumn>
+                                                    </tableColumns>
+                                                    <connections>
+                                                        <outlet property="dataSource" destination="2144" id="2172"/>
+                                                        <outlet property="delegate" destination="2144" id="2173"/>
+                                                    </connections>
+                                                </tableView>
+                                            </subviews>
+                                            <nil key="backgroundColor"/>
+                                        </clipView>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Fuh-SQ-jA3"/>
+                                        </constraints>
+                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="1684">
+                                            <rect key="frame" x="-100" y="-100" width="223" height="15"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="1683">
+                                            <rect key="frame" x="-100" y="-100" width="15" height="102"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                    </scrollView>
+                                </subviews>
+                            </view>
+                        </tabViewItem>
+                        <tabViewItem label="Dark" identifier="" id="pVe-2a-P1f">
+                            <view key="view" id="b0C-vo-hpF">
+                                <rect key="frame" x="10" y="33" width="360" height="334"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <subviews>
+                                    <scrollView horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" id="hGF-0X-zFx">
+                                        <rect key="frame" x="10" y="8" width="340" height="330"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="0UN-0a-TlO">
+                                            <rect key="frame" x="1" y="1" width="338" height="328"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="20" id="J5y-ix-ZdH">
+                                                    <rect key="frame" x="0.0" y="0.0" width="338" height="328"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                    <size key="intercellSpacing" width="3" height="2"/>
+                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                                    <tableColumns>
+                                                        <tableColumn identifier="name" width="303" minWidth="40" maxWidth="10000" id="zyj-zF-mMD">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" allowsUndo="NO" alignment="left" title="Text Cell" allowsEditingTextAttributes="YES" id="Pkq-Bp-7mI">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                        </tableColumn>
+                                                        <tableColumn identifier="color" editable="NO" width="20" minWidth="20" maxWidth="20" id="soa-rn-bWx">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="ZGe-gw-KHq">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                        </tableColumn>
+                                                    </tableColumns>
+                                                    <connections>
+                                                        <outlet property="dataSource" destination="2144" id="X1G-jK-WSs"/>
+                                                        <outlet property="delegate" destination="2144" id="fDZ-nh-s1F"/>
+                                                    </connections>
+                                                </tableView>
+                                            </subviews>
+                                            <nil key="backgroundColor"/>
+                                        </clipView>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="T68-mf-XQX"/>
+                                        </constraints>
+                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="hIG-AG-CQa">
+                                            <rect key="frame" x="-100" y="-100" width="223" height="15"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="wja-kj-5Vu">
+                                            <rect key="frame" x="-100" y="-100" width="15" height="102"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                    </scrollView>
+                                </subviews>
+                            </view>
+                        </tabViewItem>
+                    </tabViewItems>
+                </tabView>
             </subviews>
             <constraints>
                 <constraint firstItem="1040" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="07h-Be-Qb7"/>
                 <constraint firstItem="1517" firstAttribute="centerY" secondItem="1519" secondAttribute="centerY" constant="-5" id="0uR-Wu-RhC"/>
-                <constraint firstItem="1682" firstAttribute="leading" secondItem="1085" secondAttribute="leading" id="0zs-YT-pk7"/>
                 <constraint firstItem="1042" firstAttribute="top" secondItem="1040" secondAttribute="bottom" constant="9" id="1um-mL-Szt"/>
                 <constraint firstItem="1520" firstAttribute="leading" secondItem="1519" secondAttribute="trailing" constant="5" id="30q-zf-qRY"/>
                 <constraint firstItem="1497" firstAttribute="leading" secondItem="1505" secondAttribute="trailing" constant="1" id="32R-Ww-Wta"/>
@@ -2328,10 +2406,9 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="1499" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="6Gd-YR-UwY"/>
                 <constraint firstItem="1128" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="6Rt-Dl-nEH"/>
                 <constraint firstItem="q6h-n2-3a8" firstAttribute="top" secondItem="1519" secondAttribute="bottom" id="753-w2-5rN"/>
-                <constraint firstItem="1037" firstAttribute="top" secondItem="802" secondAttribute="top" constant="16" id="7iM-gH-svh"/>
+                <constraint firstItem="1037" firstAttribute="top" secondItem="802" secondAttribute="top" constant="13" id="7iM-gH-svh"/>
                 <constraint firstItem="1040" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="88v-JT-MZi"/>
                 <constraint firstItem="1044" firstAttribute="centerY" secondItem="1045" secondAttribute="centerY" constant="-5" id="8Nx-5g-ekY"/>
-                <constraint firstItem="1669" firstAttribute="top" secondItem="1682" secondAttribute="bottom" constant="10" id="8X8-bM-jcO"/>
                 <constraint firstAttribute="trailing" secondItem="v54-2I-2wr" secondAttribute="trailing" constant="30" id="9BW-v0-fwT"/>
                 <constraint firstItem="1518" firstAttribute="centerY" secondItem="1519" secondAttribute="centerY" constant="-5" id="CM5-5a-OYN"/>
                 <constraint firstItem="1034" firstAttribute="leading" secondItem="1085" secondAttribute="leading" id="CNn-vp-M3D"/>
@@ -2341,37 +2418,32 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstAttribute="bottom" secondItem="1669" secondAttribute="bottom" constant="15" id="GRk-eU-Obz"/>
                 <constraint firstItem="1499" firstAttribute="top" secondItem="1542" secondAttribute="bottom" constant="9" id="I3G-h6-HEr"/>
                 <constraint firstItem="1040" firstAttribute="top" secondItem="2185" secondAttribute="bottom" constant="9" id="ISt-G5-WmP"/>
-                <constraint firstItem="1036" firstAttribute="baseline" secondItem="v54-2I-2wr" secondAttribute="baseline" id="LJx-fA-JCi"/>
+                <constraint firstItem="0jC-UV-cbM" firstAttribute="leading" secondItem="1085" secondAttribute="leading" id="JKX-Se-BGD"/>
                 <constraint firstItem="1517" firstAttribute="leading" secondItem="1518" secondAttribute="trailing" constant="3" id="LrC-x9-AzB"/>
                 <constraint firstItem="1740" firstAttribute="centerY" secondItem="1669" secondAttribute="centerY" id="Mxl-Bt-Lmm"/>
                 <constraint firstItem="xIN-qP-ogl" firstAttribute="top" secondItem="1128" secondAttribute="bottom" constant="9" id="N4F-tp-Ye3"/>
                 <constraint firstItem="1519" firstAttribute="top" secondItem="1521" secondAttribute="bottom" constant="10" id="OBh-aS-TeB"/>
+                <constraint firstItem="1669" firstAttribute="top" secondItem="0jC-UV-cbM" secondAttribute="bottom" constant="29" id="Pr7-ub-0aW"/>
                 <constraint firstItem="2196" firstAttribute="leading" secondItem="2188" secondAttribute="trailing" constant="1" id="Qx4-WP-Nw8"/>
                 <constraint firstItem="1041" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="RN4-RH-L81"/>
                 <constraint firstItem="2188" firstAttribute="centerY" secondItem="2185" secondAttribute="centerY" id="Rpe-nI-N5h"/>
                 <constraint firstItem="1518" firstAttribute="leading" secondItem="1520" secondAttribute="trailing" constant="1" id="S1I-B9-WbE"/>
-                <constraint firstItem="1682" firstAttribute="top" secondItem="1085" secondAttribute="bottom" constant="9" id="Tak-ON-k22"/>
-                <constraint firstItem="1045" firstAttribute="leading" secondItem="1682" secondAttribute="trailing" constant="30" id="TiG-wn-eVq"/>
                 <constraint firstItem="1128" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="U1K-di-gV4"/>
-                <constraint firstItem="1740" firstAttribute="trailing" secondItem="1682" secondAttribute="trailing" id="V1T-vE-bku"/>
                 <constraint firstItem="UnY-1b-NTN" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="V8I-rs-sZ6"/>
                 <constraint firstItem="2196" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="VM2-Ha-wgU"/>
                 <constraint firstItem="1505" firstAttribute="leading" secondItem="1499" secondAttribute="trailing" constant="5" id="Veq-vf-zA9"/>
                 <constraint firstItem="UnY-1b-NTN" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="VhL-v5-EOm"/>
                 <constraint firstItem="2196" firstAttribute="centerY" secondItem="2185" secondAttribute="centerY" id="W50-pu-PZf"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="1499" secondAttribute="bottom" constant="15" id="WqO-mA-gjk"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="1499" secondAttribute="bottom" constant="16" id="WqO-mA-gjk"/>
                 <constraint firstItem="q6h-n2-3a8" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="agH-Ty-N6d"/>
-                <constraint firstItem="v54-2I-2wr" firstAttribute="baseline" secondItem="1036" secondAttribute="firstBaseline" id="bAf-2i-MTh"/>
-                <constraint firstItem="1039" firstAttribute="top" secondItem="1085" secondAttribute="bottom" constant="9" id="bwP-pO-qGY"/>
-                <constraint firstItem="1085" firstAttribute="top" secondItem="1037" secondAttribute="bottom" constant="8" symbolic="YES" id="cau-FV-c1C"/>
+                <constraint firstItem="1039" firstAttribute="top" secondItem="1085" secondAttribute="bottom" constant="15" id="bwP-pO-qGY"/>
+                <constraint firstItem="1085" firstAttribute="top" secondItem="1037" secondAttribute="bottom" constant="20" id="cau-FV-c1C"/>
                 <constraint firstItem="1083" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="czE-lF-bOr"/>
-                <constraint firstItem="1034" firstAttribute="baseline" secondItem="1036" secondAttribute="baseline" id="gnd-q3-Ilc"/>
                 <constraint firstItem="1521" firstAttribute="top" secondItem="UnY-1b-NTN" secondAttribute="bottom" constant="9" id="h60-Jm-iq9"/>
-                <constraint firstItem="1039" firstAttribute="leading" secondItem="1682" secondAttribute="trailing" constant="10" id="hgk-h2-1CQ"/>
                 <constraint firstItem="1083" firstAttribute="leading" secondItem="1046" secondAttribute="trailing" constant="3" id="hj3-hN-nDf"/>
                 <constraint firstItem="1042" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="jSN-iU-XcU"/>
                 <constraint firstItem="1738" firstAttribute="centerY" secondItem="1669" secondAttribute="centerY" id="js1-Pb-T93"/>
-                <constraint firstItem="1037" firstAttribute="centerY" secondItem="1036" secondAttribute="centerY" id="k11-dq-m5q"/>
+                <constraint firstItem="1034" firstAttribute="centerY" secondItem="1036" secondAttribute="centerY" id="k11-dq-m5q"/>
                 <constraint firstItem="1542" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="kO2-0M-Ugk"/>
                 <constraint firstItem="1046" firstAttribute="leading" secondItem="1044" secondAttribute="trailing" constant="1" id="lI8-cX-zTo"/>
                 <constraint firstItem="1669" firstAttribute="leading" secondItem="1085" secondAttribute="leading" id="lep-L6-nCB"/>
@@ -2383,26 +2455,27 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
                 <constraint firstItem="1083" firstAttribute="centerY" secondItem="1045" secondAttribute="centerY" constant="-5" id="oSA-hL-2he"/>
                 <constraint firstItem="1046" firstAttribute="centerY" secondItem="1045" secondAttribute="centerY" constant="-5" id="ohG-5j-dFT"/>
                 <constraint firstItem="v54-2I-2wr" firstAttribute="leading" secondItem="1036" secondAttribute="trailing" constant="12" symbolic="YES" id="oxL-Wb-OXr"/>
-                <constraint firstItem="1682" firstAttribute="width" secondItem="802" secondAttribute="width" multiplier="3/7" id="oyD-c7-AK6"/>
                 <constraint firstItem="UnY-1b-NTN" firstAttribute="top" secondItem="xIN-qP-ogl" secondAttribute="bottom" constant="9" id="qSa-Cf-Vj8"/>
                 <constraint firstItem="1045" firstAttribute="top" secondItem="1041" secondAttribute="bottom" constant="5" id="rGS-R2-10k"/>
                 <constraint firstItem="1740" firstAttribute="leading" secondItem="1738" secondAttribute="trailing" constant="5" id="rkP-ab-hmB"/>
                 <constraint firstItem="1497" firstAttribute="centerY" secondItem="1499" secondAttribute="centerY" id="sig-Tk-KWs"/>
+                <constraint firstItem="0jC-UV-cbM" firstAttribute="top" secondItem="1085" secondAttribute="bottom" constant="15" id="tRA-Pu-uUC"/>
                 <constraint firstItem="xIN-qP-ogl" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="vAd-Sh-CJY"/>
                 <constraint firstItem="1042" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="vgo-wx-KMP"/>
+                <constraint firstItem="1037" firstAttribute="centerY" secondItem="1034" secondAttribute="centerY" id="vpj-38-0A7"/>
                 <constraint firstItem="1542" firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" id="vyL-HG-CgB"/>
                 <constraint firstItem="xIN-qP-ogl" firstAttribute="leading" secondItem="1039" secondAttribute="leading" id="vyO-eH-iNc"/>
                 <constraint firstItem="1044" firstAttribute="leading" secondItem="1045" secondAttribute="trailing" constant="5" id="w43-rk-Ykx"/>
+                <constraint firstItem="v54-2I-2wr" firstAttribute="centerY" secondItem="1036" secondAttribute="centerY" id="wHK-Ma-eNe"/>
                 <constraint firstItem="1738" firstAttribute="leading" secondItem="1669" secondAttribute="trailing" constant="5" id="x8S-qI-1x7"/>
                 <constraint firstItem="1036" firstAttribute="leading" secondItem="1037" secondAttribute="trailing" constant="10" id="xPc-Pi-SU3"/>
-                <constraint firstItem="1034" firstAttribute="baseline" secondItem="1037" secondAttribute="firstBaseline" id="xk7-gj-cHh"/>
                 <constraint firstItem="2185" firstAttribute="top" secondItem="1039" secondAttribute="bottom" constant="9" id="xyX-Pw-PqC"/>
                 <constraint firstItem="1041" firstAttribute="top" secondItem="1042" secondAttribute="bottom" constant="9" id="y6U-1y-Z26"/>
                 <constraint firstItem="1128" firstAttribute="top" secondItem="1045" secondAttribute="bottom" id="yPB-4e-MCn"/>
                 <constraint firstAttribute="trailing" secondItem="1085" secondAttribute="trailing" constant="20" id="ydA-be-JIe"/>
                 <constraint firstAttribute="trailing" secondItem="1039" secondAttribute="trailing" constant="20" id="yoh-2E-iOA"/>
             </constraints>
-            <point key="canvasLocation" x="751" y="1093.5"/>
+            <point key="canvasLocation" x="751" y="1089"/>
         </customView>
         <menu id="1547" userLabel="Context Menu">
             <items>
@@ -2420,7 +2493,7 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
             <connections>
                 <outlet property="delegate" destination="-2" id="1555"/>
             </connections>
-            <point key="canvasLocation" x="616" y="837"/>
+            <point key="canvasLocation" x="616" y="836.5"/>
         </menu>
         <customView id="D6L-76-0Ik" userLabel="Pick SSH client binary Accessory View">
             <rect key="frame" x="0.0" y="0.0" width="404" height="44"/>
@@ -2653,9 +2726,9 @@ Warning: If Sequel Ace and the server do not have at least one cipher suite in c
         </customView>
     </objects>
     <resources>
-        <image name="NSAddTemplate" width="18" height="16"/>
+        <image name="NSAddTemplate" width="18" height="17"/>
         <image name="NSAdvanced" width="32" height="32"/>
-        <image name="NSRemoveTemplate" width="18" height="4"/>
+        <image name="NSRemoveTemplate" width="18" height="5"/>
         <image name="resetTemplate" width="16" height="16"/>
     </resources>
 </document>

--- a/Source/Other/CategoryAdditions/SPWindowAdditions.m
+++ b/Source/Other/CategoryAdditions/SPWindowAdditions.m
@@ -46,21 +46,21 @@
 	}
 
 	NSSize viewSize = view.fittingSize;
-	NSRect frame    = [self frame];
+	NSRect frame = [self frame];
 
-	if(viewSize.height < [self contentMinSize].height) {
-		viewSize.height = [self contentMinSize].height;
-	}
-	if(viewSize.width < [self contentMinSize].width) {
-		viewSize.width = [self contentMinSize].width;
-	}
+	viewSize.height = MAX(viewSize.height, [self contentMinSize].height);
+	viewSize.width = MAX(viewSize.width, [self contentMinSize].width);
 
 	CGFloat newHeight = viewSize.height + (self.frame.size.height - self.contentView.frame.size.height);
-	frame.origin.y += frame.size.height - newHeight;
 
 	frame.size.height = MAX(newHeight, [self minSize].height);
 	//If width is bigger, keep it the same for consistency
 	frame.size.width  = MAX(MAX(self.contentView.frame.size.width, viewSize.width + (self.frame.size.width - self.contentView.frame.size.width)), [self minSize].width);
+  
+  // Based on mainscreen frame to centralize the current window
+  NSRect screenFrame = [[NSScreen mainScreen] frame];
+  frame.origin.x = (screenFrame.size.width - frame.size.width) / 2;
+  frame.origin.y = (screenFrame.size.height - frame.size.height) / 2;
 
 	[self setFrame:frame display:YES animate:YES];
 }

--- a/Source/Other/Data/SPConstants.h
+++ b/Source/Other/Data/SPConstants.h
@@ -312,6 +312,7 @@ extern NSString *SPDisplayTableViewColumnTypes;
 extern NSString *SPDisplayCommentsInTablesList;
 extern NSString *SPCustomQueryMaxHistoryItems;
 extern NSString *SPAppearance;
+extern NSString *SPEffectiveAppearance;
 
 // Tables Prefpane
 extern NSString *SPReloadAfterAddingRow;
@@ -349,6 +350,7 @@ extern NSString *SPKeepAliveInterval;
 // Editor Prefpane
 extern NSString *SPCustomQueryEnableSyntaxHighlighting;
 extern NSString *SPCustomQueryEditorFont;
+
 extern NSString *SPCustomQueryEditorTextColor;
 extern NSString *SPCustomQueryEditorBackgroundColor;
 extern NSString *SPCustomQueryEditorCaretColor;
@@ -360,6 +362,19 @@ extern NSString *SPCustomQueryEditorBacktickColor;
 extern NSString *SPCustomQueryEditorVariableColor;
 extern NSString *SPCustomQueryEditorHighlightQueryColor;
 extern NSString *SPCustomQueryEditorSelectionColor;
+
+extern NSString *SPCustomQueryEditorDarkModeTextColor;
+extern NSString *SPCustomQueryEditorDarkModeBackgroundColor;
+extern NSString *SPCustomQueryEditorDarkModeCaretColor;
+extern NSString *SPCustomQueryEditorDarkModeCommentColor;
+extern NSString *SPCustomQueryEditorDarkModeSQLKeywordColor;
+extern NSString *SPCustomQueryEditorDarkModeNumericColor;
+extern NSString *SPCustomQueryEditorDarkModeQuoteColor;
+extern NSString *SPCustomQueryEditorDarkModeBacktickColor;
+extern NSString *SPCustomQueryEditorDarkModeVariableColor;
+extern NSString *SPCustomQueryEditorDarkModeHighlightQueryColor;
+extern NSString *SPCustomQueryEditorDarkModeSelectionColor;
+
 extern NSString *SPCustomQueryAutoIndent;
 extern NSString *SPCustomQueryAutoPairCharacters;
 extern NSString *SPCustomQueryAutoUppercaseKeywords;

--- a/Source/Other/Data/SPConstants.m
+++ b/Source/Other/Data/SPConstants.m
@@ -122,6 +122,7 @@ NSString *SPCustomQueryMaxHistoryItems           = @"CustomQueryMaxHistoryItems"
 NSString *SPCustomQuerySaveHistoryIndividually   = @"CustomQuerySaveHistoryIndividually";
 NSString *SPSaveApplicationUsageAnalytics        = @"SaveApplicationUsageAnalytics";
 NSString *SPAppearance                           = @"Appearance";
+NSString *SPEffectiveAppearance                  = @"effectiveAppearance";
 
 // Tables Prefpane
 NSString *SPReloadAfterAddingRow                 = @"ReloadAfterAddingRow";
@@ -161,6 +162,8 @@ NSString *SPKeepAliveInterval                    = @"KeepAliveInterval";
 // Editor Prefpane
 NSString *SPCustomQueryEnableSyntaxHighlighting  = @"CustomQueryEnableSyntaxHighlighting";
 NSString *SPCustomQueryEditorFont                = @"CustomQueryEditorFont";
+
+// Editor colors - Light mode (default)
 NSString *SPCustomQueryEditorTextColor           = @"CustomQueryEditorTextColor";
 NSString *SPCustomQueryEditorBackgroundColor     = @"CustomQueryEditorBackgroundColor";
 NSString *SPCustomQueryEditorCaretColor          = @"CustomQueryEditorCaretColor";
@@ -172,6 +175,20 @@ NSString *SPCustomQueryEditorBacktickColor       = @"CustomQueryEditorBacktickCo
 NSString *SPCustomQueryEditorVariableColor       = @"CustomQueryEditorVariableColor";
 NSString *SPCustomQueryEditorHighlightQueryColor = @"CustomQueryEditorHighlightQueryColor";
 NSString *SPCustomQueryEditorSelectionColor      = @"CustomQueryEditorSelectionColor";
+
+// Editor colors - Dark mode (macOS 10.14 and newer)
+NSString *SPCustomQueryEditorDarkModeTextColor           = @"CustomQueryEditorDarkModeTextColor";
+NSString *SPCustomQueryEditorDarkModeBackgroundColor     = @"CustomQueryEditorDarkModeBackgroundColor";
+NSString *SPCustomQueryEditorDarkModeCaretColor          = @"CustomQueryEditorDarkModeCaretColor";
+NSString *SPCustomQueryEditorDarkModeCommentColor        = @"CustomQueryEditorDarkModeCommentColor";
+NSString *SPCustomQueryEditorDarkModeSQLKeywordColor     = @"CustomQueryEditorDarkModeSQLKeywordColor";
+NSString *SPCustomQueryEditorDarkModeNumericColor        = @"CustomQueryEditorDarkModeNumericColor";
+NSString *SPCustomQueryEditorDarkModeQuoteColor          = @"CustomQueryEditorDarkModeQuoteColor";
+NSString *SPCustomQueryEditorDarkModeBacktickColor       = @"CustomQueryEditorDarkModeBacktickColor";
+NSString *SPCustomQueryEditorDarkModeVariableColor       = @"CustomQueryEditorDarkModeVariableColor";
+NSString *SPCustomQueryEditorDarkModeHighlightQueryColor = @"CustomQueryEditorDarkModeHighlightQueryColor";
+NSString *SPCustomQueryEditorDarkModeSelectionColor      = @"CustomQueryEditorDarkModeSelectionColor";
+
 NSString *SPCustomQueryAutoIndent                = @"CustomQueryAutoIndent";
 NSString *SPCustomQueryAutoPairCharacters        = @"CustomQueryAutoPairCharacters";
 NSString *SPCustomQueryAutoUppercaseKeywords     = @"CustomQueryAutoUppercaseKeywords";

--- a/Source/Views/TextViews/SPTextView.h
+++ b/Source/Views/TextViews/SPTextView.h
@@ -106,6 +106,8 @@ typedef struct {
 	BOOL enableSyntaxHighlighting;
 
 	BOOL syntaxHighlightingApplied;
+  NSArray *lightModeColorKeys;
+  NSArray *darkModeColorKeys;
 }
 
 @property (strong) NSColor* queryHiliteColor;

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -20,11 +20,49 @@ Please check out [this page](migrating-from-sequel-pro.html) for info on how to 
 
 **I am having trouble connecting to a database. It says: Can't connect to local MySQL server through socket '/tmp/mysql.sock' (2)**
 
-Unfortunately, due to sandboxing nature, Sequel Ace is not allowed to connect to the sockets which are out of the Sandbox. As a workaround, you can create a socket in `~/Library/Containers/com.sequel-ace.sequel-ace/Data` and connect to it. This can be done by putting these lines to your MySQL configuration file (usually, `my.cnf`):
+Unfortunately, due to sandboxing nature, Sequel Ace is not allowed to connect to the sockets which are out of the Sandbox. As a workaround, you can create a socket in `~/Library/Containers/com.sequel-ace.sequel-ace/Data` and connect to it. This can be done by putting these lines to your MySQL configuration file (usually, `my.cnf`). First, make a note of the file already specified in this file, typically, `/tmp/mysql.sock`.
  ```
  [mysqld]
  socket=/Users/YourUserName/Library/Containers/com.sequel-ace.sequel-ace/Data/mysql.sock
  ```
+To allow other database applications to continue working, make a symbolic link from the new socket file to the one previously used, like this:
+```
+# ln -s /Users/YourUserName/Library/Containers/com.sequel-ace.sequel-ace/Data/mysql.sock /tmp/mysql.sock
+```
+
+If you are still having trouble using the new socket connection, it may be a permission problem, which you can check and correct:
+```
+# ls -la /Users/YourUserName/Library/Containers/com.sequel-ace.sequel-ace/Data/
+drwx------  14 jan     staff    448 14 Jun 09:41 .
+drwx------@  4 jan     staff    128 13 Jun 11:23 ..
+lrwxr-xr-x   1 jan     staff     31 13 Jun 11:23 .CFUserTextEncoding -> ../../../../.CFUserTextEncoding
+drwxr-xr-x@  2 jan     staff     64 13 Jun 11:23 .keys
+lrwxr-xr-x   1 jan     staff     19 13 Jun 11:23 Desktop -> ../../../../Desktop
+drwx------   2 jan     staff     64 13 Jun 11:23 Documents
+lrwxr-xr-x   1 jan     staff     21 13 Jun 11:23 Downloads -> ../../../../Downloads
+drwx------  32 jan     staff   1024 13 Jun 11:23 Library
+lrwxr-xr-x   1 jan     staff     18 13 Jun 11:23 Movies -> ../../../../Movies
+lrwxr-xr-x   1 jan     staff     17 13 Jun 11:23 Music -> ../../../../Music
+lrwxr-xr-x   1 jan     staff     20 13 Jun 11:23 Pictures -> ../../../../Pictures
+drwx------   2 jan     staff     64 13 Jun 11:23 SystemData
+srwxrwxrwx   1 _mysql  _mysql     0 14 Jun 09:41 mysql.sock
+drwx------   2 jan     staff     64 13 Jun 22:26 tmp
+```
+Note that neither the target directory nor its containing directory allow any access to user `_mysql`
+
+You can change the group to `_mysql` and set group permissions accordingly:
+```
+# for d in \
+  /Users/YourUserName/Library/Containers/com.sequel-ace.sequel-ace/Data/ \
+  /Users/YourUserName/Library/Containers/com.sequel-ace.sequel-ace/ \
+  /Users/YourUserName/Library/Containers/ \
+  /Users/YourUserName/Library/Containers/ \
+  /Users/YourUserName/
+do
+  chgrp $d _mysql
+  chmod g+rwx $d
+done
+```
 
 **I'm having trouble connecting to a MySQL 4 or MySQL 5 database on localhost with a MAMP install.**
 


### PR DESCRIPTION
For keep tracking!

## Changes:
Mostly on supporting dark mode setting for query editor. Also added some minor changes to improve preference panels.

### Editor's dark mode
- [x] Add dark mode color settings for editor and default colors list for it
- [x] Handle editor change appearance changes along with system appearance changes
- [x] Fallback colors for only light mode themes
- [x] Handle color pickers according appearance mode
- [ ] WIP: Handle import/exporting themes
- [ ] WIP: Syntax highlight is broken in favorite queries list

### Preference panel size and centralizing behavior
- [x] Fixed some minor glitches when opening/switching preference panels and adjust size.
- [x] Fixed conflict constraints on Preference window:
```objective-c
NSSize viewSize = view.fittingSize; // SPWindowAdditions.m

Conflicting constraints detected: (
    "<NSLayoutConstraint:0x600001306080 SPFontPreviewTextField:0x13309e890.centerY == NSTextField:0x13309e570.centerY   (active)>",
    "<NSAutoresizingMaskLayoutConstraint:0x6000013245f0 h=-&- v=-&- NSView:0x1330b8a80.minY == 0   (active, names: '|':NSBox:0x1330b87e0 )>",
    "<NSLayoutConstraint:0x600001306210 NSButton:0x1330ba520.centerY == NSTextField:0x13309e570.centerY   (active)>",
    "<NSLayoutConstraint:0x600001305d60 SPFontPreviewTextField:0x13309e890.height == 22   (active)>",
    "<NSLayoutConstraint:0x6000013363f0 V:[NSBox:0x1330b87e0]-(>=70)-|   (active, names: '|':NSView:0x12517e190 )>",
    "<NSLayoutConstraint:0x600001300e10 V:[SPFontPreviewTextField:0x13309e890]-(5)-[NSBox:0x1330b79a0]   (active)>",
    "<NSLayoutConstraint:0x600001305860 NSButton:0x1330b7d70.height == 22   (active)>",
    "<NSLayoutConstraint:0x600001301040 V:[NSBox:0x1330b79a0]-(9)-[NSButton:0x1330b7d70]   (active)>",
    "<NSLayoutConstraint:0x600001336490 V:[NSButton:0x1330b7d70]-(15)-|   (active, names: '|':NSView:0x12517e190 )>",
    "<NSLayoutConstraint:0x6000013057c0 NSBox:0x1330b79a0.height == 1   (active)>",
    "<NSLayoutConstraint:0x600001306170 V:[NSButton:0x1330ba520]-(0)-|   (active, names: '|':NSView:0x1330b8a80 )>",
    "<NSLayoutConstraint:0x600001305e50 NSButton:0x1330ba520.height == 20   (active)>"
).

Will attempt to recover by breaking <NSLayoutConstraint:0x600001305d60 SPFontPreviewTextField:0x13309e890.height == 22   (active)>.
```

## Additional notes:
In Xcode's editor, many users prefer to keep the editor's appearance consistent when switching between light and dark modes. It would be nice to have separate themes for each mode. Another option is to have themes that support both light and dark modes, which gives a more modern look. However, it seems simpler to stick to one strategy instead of having themes with different modes.